### PR TITLE
Properly escape the quotes in the data

### DIFF
--- a/lib/curl_logger_dio_interceptor.dart
+++ b/lib/curl_logger_dio_interceptor.dart
@@ -55,8 +55,9 @@ class CurlLoggerDioInterceptor extends Interceptor {
         options.data = Map.fromEntries(options.data.fields);
       }
 
-      final data = json.encode(options.data).replaceAll('"', '\\"');
-      components.add('-d "$data"');
+      final data =
+          options.data is String ? options.data : json.encode(options.data);
+      components.add("-d '$data'");
     }
 
     components.add('"${options.uri.toString()}"');


### PR DESCRIPTION
I would earlier get stuff like
 -d "\"{\\"cart\\":true,\\"RxNumber\\":\\"000635-1-3\\"}\""

Now it's -
 -d '{"cart":true,"RxNumber":"000635-1-3"}'